### PR TITLE
#199 Support Proxy Settings

### DIFF
--- a/src/main/java/org/aksw/gerbil/http/HttpManagement.java
+++ b/src/main/java/org/aksw/gerbil/http/HttpManagement.java
@@ -19,9 +19,11 @@ package org.aksw.gerbil.http;
 import java.util.concurrent.Semaphore;
 
 import org.aksw.gerbil.config.GerbilConfiguration;
+import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +35,8 @@ public class HttpManagement {
 
     public static final String MAXIMUM_TIME_TO_WAIT_KEY = "org.aksw.gerbil.annotator.http.HttpManagement.maxWaitingTime";
     public static final String CHECK_INTERVAL_KEY = "org.aksw.gerbil.annotator.http.HttpManagement.checkInterval";
-
+    public static final String PROXY_HOST_KEY = "org.aksw.gerbil.annotator.http.HttpManagement.proxyHost";
+    public static final String PROXY_PORT_KEY = "org.aksw.gerbil.annotator.http.HttpManagement.proxyPort";
     /**
      * TODO move this list into the property files.
      */
@@ -48,7 +51,7 @@ public class HttpManagement {
 
     public static final long DEFAULT_WAITING_TIME = 60000;
     public static final long DEFAULT_CHECK_INTERVAL = 10000;
-
+    public static final int DEFAULT_PROXY_PORT = 8080;
     /**
      * The time the system should wait before sending a new request to a domain
      * that could block the system.
@@ -194,6 +197,16 @@ public class HttpManagement {
     public HttpClientBuilder generateHttpClientBuilder() {
         HttpClientBuilder builder = HttpClientBuilder.create();
         builder.setUserAgent(userAgent);
+
+        String proxyHost = GerbilConfiguration.getInstance().getString(PROXY_HOST_KEY);
+        int proxyPort = GerbilConfiguration.getInstance().getInt(PROXY_PORT_KEY, DEFAULT_PROXY_PORT);
+
+        if (proxyHost != null) {
+            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+            DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+            builder.setRoutePlanner(routePlanner);
+        }
+
         return builder;
     }
 }

--- a/src/main/properties/gerbil.properties
+++ b/src/main/properties/gerbil.properties
@@ -96,3 +96,7 @@ org.aksw.gerbil.dataset.check.FileBasedCachingEntityCheckerManager.cacheFile=${o
 ### Wikipedia API Cache files (deprecated)
 org.aksw.gerbil.utils.SingletonWikipediaApi.TitleCacheFile=${org.aksw.gerbil.DataPath}/cache/wiki-title-id.cache
 org.aksw.gerbil.utils.SingletonWikipediaApi.RedirectCacheFile=${org.aksw.gerbil.DataPath}/cache/wiki-id-id.cache
+
+### Proxy Settings
+#org.aksw.gerbil.annotator.http.HttpManagement.proxyHost=localhost
+#org.aksw.gerbil.annotator.http.HttpManagement.proxyPort=8080


### PR DESCRIPTION
HttpManagement has been modified for GERBIL to support proxy environment. Proxy settings can be given in gerbil.properties as the below:

```
org.aksw.gerbil.annotator.http.HttpManagement.proxyHost=exampleHost
org.aksw.gerbil.annotator.http.HttpManagement.proxyPort=8080
```

@MichaelRoeder I received build errors from Travis CI. What could be the problem?